### PR TITLE
Update library import on weatherViewController

### DIFF
--- a/Clima/WeatherViewController.swift
+++ b/Clima/WeatherViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import CoreLocation // Swift 5 doesn't allow mutiple Inheritance 
 
 
 class WeatherViewController: UIViewController {


### PR DESCRIPTION
As Swift 5 doesn't allow multiple inheritances, we need to make sure that the correct library has been imported before creating an object from CoreLocation.